### PR TITLE
set up getOrCreateNode so that it does not write to the page unless in edit mode

### DIFF
--- a/gato-lib/src/main/java/edu/txstate/its/gato/GatoUtils.java
+++ b/gato-lib/src/main/java/edu/txstate/its/gato/GatoUtils.java
@@ -1097,8 +1097,12 @@ public final class GatoUtils {
     try {
       if (!n.hasNode(childName)) {
         Session scs = sc.getJCRSession(n.getSession().getWorkspace().getName());
-        Node scchild = scs.getNodeByIdentifier(n.getIdentifier()).addNode(childName, type);
-        scs.save();
+        if (!tf.isEditMode() && (!childName.startsWith("empty-") || !n.getName().equals("global-data"))) {
+          return this.getOrCreateNode(scs.getNode("/global-data"), "empty-"+type.replaceAll("[^\\w-]+", "-"), type);
+        } else {
+          Node scchild = scs.getNodeByIdentifier(n.getIdentifier()).addNode(childName, type);
+          scs.save();
+        }
       }
       child = tf.asContentMap(n.getNode(childName));
     } catch (Exception e) {


### PR DESCRIPTION
Hopefully this will help with race conditions during publishing.

I think what's happening is that during a publish Magnolia is removing all non-page nodes and then replacing them one by one, so that it can avoid disturbing the subpage nodes.

So if you read the page during that process, getOrCreateNode might see the page is missing the node before the publish has moved it over, try to write it, and then the publish comes in later and tries to write and it generates a conflict. The publish crashes, the node stays locked, the rest of the to-be-published nodes are missing - all the problems we've observed.

The solution here is when in public mode and it looks like we should create a node, we instead present an empty node from underneath /global-data. This way getOrCreateNode still returns a real node so @cms.area doesn't crash, but this node is not being written to the page so there's no race condition.

